### PR TITLE
Adding UnitId field to NutrientInfoDto

### DIFF
--- a/src/Esha.Genesis.Services.Client/NutrientInfoDto.cs
+++ b/src/Esha.Genesis.Services.Client/NutrientInfoDto.cs
@@ -24,6 +24,8 @@ namespace Esha.Genesis.Services.Client
 
         private QuantityDto _weightField;
 
+        private Guid? _unitIdField;
+
         /// <remarks />
         [XmlElement]
         public QuantityDto Unknown
@@ -70,6 +72,14 @@ namespace Esha.Genesis.Services.Client
         {
             get => _quantityField;
             set => _quantityField = value;
+        }
+
+        /// <remarks />
+        [XmlElement(IsNullable = true)]
+        public Guid? UnitId
+        {
+            get => _unitIdField;
+            set => _unitIdField = value;
         }
     }
 }


### PR DESCRIPTION
 To populate this field, we will cache NutrientDto information, lookup the UnitId value for each NutrientInfoDto returned from an analysis, and then add the UnitId to each NutrientInfoDto.